### PR TITLE
feat(workflow): member github permission file

### DIFF
--- a/members_permissions.json
+++ b/members_permissions.json
@@ -1,0 +1,62 @@
+{
+  "organizations": {
+    "orgA": {
+      "organization_members": {
+        "alice": { "teams": ["devs", "reviewers"] },
+        "bob": { "teams": ["devs"] },
+        "carol": { "teams": ["admins"] }
+      },
+      "outside_collaborators": {
+        "dave": { "repositories": { "repoA": "read", "repoB": "triage" } },
+        "eve": { "repositories": { "repoC": "write" } }
+      },
+      "teams": {
+        "devs": {
+          "repositories": {
+            "repoA": "write",
+            "repoB": "read"
+          }
+        },
+        "reviewers": {
+          "repositories": {
+            "repoA": "triage"
+          }
+        },
+        "admins": {
+          "repositories": {
+            "repoA": "admin",
+            "repoB": "admin",
+            "repoC": "maintain"
+          }
+        }
+      }
+    },
+    "orgB": {
+      "organization_members": {
+        "frank": { "teams": ["backend", "reviewers"] },
+        "grace": { "teams": ["frontend"] }
+      },
+      "outside_collaborators": {
+        "hank": { "repositories": { "repoX": "read", "repoY": "write" } }
+      },
+      "teams": {
+        "backend": {
+          "repositories": {
+            "repoX": "write",
+            "repoY": "maintain"
+          }
+        },
+        "frontend": {
+          "repositories": {
+            "repoZ": "write"
+          }
+        },
+        "reviewers": {
+          "repositories": {
+            "repoX": "triage"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
resolves #141 

The members_permissions.json file will be used to
- update each github user's team and permission in each org/repo easily
- display each user's github permission info

The members_permissions.json file has the following structure
- organization
  - organization_member
    - included team
  - outside_collaborator
    - repository
      - permissions
  - teams
    - repository
      - permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a comprehensive permissions framework for managing roles and access levels across organizations.
  - Enables clear definition of organization members, external contributors, and team-based permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->