### PR TITLE
chore(profile): add Philemon Ukane

### DIFF
--- a/profile-submission.json
+++ b/profile-submission.json
@@ -289,6 +289,11 @@
       "github_handle": "muzhangse",
       "full_name": "Frank Zhang",
       "github_trial_issue_link": "https://github.com/holdex/trial/issues/731"
+    },
+    {
+      "github_handle": "ukane-philemon",
+      "full_name": "Philemon Ukane",
+      "github_trial_issue_link": "https://github.com/holdex/trial/issues/598"
     }
-  ]    
+  ]
 }


### PR DESCRIPTION
This commit adds a new profile entry for Philemon Ukane.

Close #598 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Added a new team profile for "Philemon Ukane" to the team profiles list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->