### PR TITLE
chore(profile): add Vadym Mirvald

### DIFF
--- a/profile-submission.json
+++ b/profile-submission.json
@@ -1,6 +1,11 @@
 {
   "team_profiles": [
     {
+      "github_handle": "mirvald-space",
+      "full_name": "Vadym Mirvald",
+      "github_trial_issue_link": "https://github.com/holdex/trial/issues/613"
+    },
+    {
       "github_handle": "jediDean",
       "full_name": "Jesse Dean",
       "github_trial_issue_link": "https://github.com/holdex/trial/issues/364"
@@ -220,4 +225,5 @@
       "full_name": "Nerguibaatar Bat-Erdene",
       "github_trial_issue_link": "https://github.com/holdex/trial/issues/581"
     }
+  ]
 }


### PR DESCRIPTION
Closes #613

Adds a new team profile entry for Vadym Mirvald (GitHub: mirvald-space)
to the profile-submission.json file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a new team profile for Vadym Mirvald (GitHub: mirvald-space) to the team directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->