### PR TITLE
feat(profile): add Garuda Casasena to profile submissions

### DIFF
--- a/profile-submission.json
+++ b/profile-submission.json
@@ -264,6 +264,11 @@
       "github_handle": "rainwolf",
       "full_name": "Walied Othman",
       "github_trial_issue_link": "https://github.com/holdex/trial/issues/654"
+    },
+    {
+      "github_handle": "Gcsena",
+      "full_name": "Garuda Casasena",
+      "github_trial_issue_link": "https://github.com/holdex/trial/issues/727"
     }
   ]    
 }


### PR DESCRIPTION
Adds my profile to the `profile-submission.json` file.

GitHub handle: **Gcsena**  
Full name: **Garuda Casasena**

Resolves: https://github.com/holdex/trial/issues/727

✅ All requested changes have been addressed:
- ✔️ Commit is now **verified**
- ✔️ PR title and description follow the **guidelines**
- ✔️ Linked the issue **manually** as requested
- ✔️ Time spent has been updated via the **PR Time Tracker bot**


![459631179-1b67d3e9-0776-4daa-b24d-1d1aba2c830b](https://github.com/user-attachments/assets/72ea1b82-90be-467e-a9f8-fce408360be0)
![459631169-bf1c1ede-f6c2-4421-861a-e6957e4b6d7a](https://github.com/user-attachments/assets/f68f487f-8ade-4c5f-ae97-8724d06b5ffd)
![459631183-aa0e61af-d373-4249-b747-78702fa6ab30](https://github.com/user-attachments/assets/8756fa7b-0768-41c9-837f-6b8a075c6eec)


