### PR TITLE
add nisan to profile-submission.json

### DIFF
--- a/profile-submission.json
+++ b/profile-submission.json
@@ -1,6 +1,11 @@
 {
   "team_profiles": [
     {
+      "github_handle": "eater-of-lemons",
+      "full_name": "Nisan Harmanci",
+      "github_trial_issue_link": "https://github.com/holdex/trial/issues/895"
+    }
+    {
       "github_handle": "15077693d",
       "full_name": "Yiu Lap Sang",
       "github_trial_issue_link": "https://github.com/holdex/trial/issues/788"


### PR DESCRIPTION
added nisan (python engineer) to the list. ready for technical test. 

resolves #895 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new team profile to the public dataset: Nisan Harmanci (GitHub: @eater-of-lemons). This profile will appear anywhere team profiles are shown and be available via the public API/feeds. No other entries were changed, ensuring continuity for existing integrations while keeping the team directory current. No functional changes otherwise for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->