### PR TITLE
chore(profile): Add profile anataliocs(Chris Anatalio) #1012

### DIFF
--- a/profile-submission.json
+++ b/profile-submission.json
@@ -354,6 +354,11 @@
       "github_handle": "Risyandi",
       "full_name": "Ris yandi",
       "github_trial_issue_link": "https://github.com/holdex/trial/issues/936"
+    },
+    {
+      "github_handle": "anataliocs",
+      "full_name": "Chris Anatalio",
+      "github_trial_issue_link": "https://github.com/holdex/trial/issues/1012"
     }
   ]
 }


### PR DESCRIPTION
#1012 

**Title:**
Add new profile entry for `anataliocs`

**Description:**
This pull request adds a new profile entry to the `profile-submission.json` file.

**Changes:**
Added new user anataliocs (Chris Anatalio), Included GitHub trial issue link

**GitHub handle:** anataliocs
**Full name:** Chris Anatalio
**Trial issue:** https://github.com/holdex/trial/issues/1012

closes holdex/trial#1012



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added a new team profile for Chris Anatalio (GitHub: anataliocs) with relevant trial reference, keeping the contributor roster current across team and profile views.
- Documentation
  - Updated visible team listing and contributor references to include the new member, improving clarity for users browsing contributor details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->